### PR TITLE
docs: shining-repo polish — community files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: [lacymorrow]
+patreon: lacymorrow
+custom: ["https://buymeacoffee.com/lm", "https://lacymorrow.com/donate"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: A marker is missing, wrong, or causing a problem
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Extension version
+      placeholder: "0.3.0"
+    validations:
+      required: true
+
+  - type: input
+    id: vscode
+    attributes:
+      label: VS Code version
+      description: From Help → About
+      placeholder: "1.95.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      options:
+        - JavaScript
+        - TypeScript
+        - JSX
+        - TSX
+        - C
+        - C++
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: snippet
+    attributes:
+      label: Minimal code snippet that reproduces the bug
+      render: javascript
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see at the closing brace?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What did the extension show (or fail to show)?
+      description: Screenshots welcome.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,6 +28,8 @@ body:
         - TypeScript
         - JSX
         - TSX
+        - MJS
+        - CJS
         - C
         - C++
         - Other
@@ -38,7 +40,6 @@ body:
     id: snippet
     attributes:
       label: Minimal code snippet that reproduces the bug
-      render: javascript
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Marketplace listing
+    url: https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker
+    about: Install, rate, or review the extension.
+  - name: Discussions
+    url: https://github.com/lacymorrow/vscode-if-end-marker/discussions
+    about: Ask questions or share patterns.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,16 @@
+name: Feature request
+description: Suggest a new marker behavior, language, or configuration option
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Your proposed change
+      description: API / behavior / configuration sketch

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for the PR! Quick checklist below. -->
+
+## Summary
+
+<!-- What does this change, and why? -->
+
+## How to test
+
+```bash
+npm test
+```
+
+## Checklist
+
+- [ ] `npm test` passes locally
+- [ ] Updated the README if a public option changed
+- [ ] PR is focused (one logical change)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+`vscode-if-end-marker` parses your source code and adds inline editor decorations. If you find a security issue — particularly anything around:
+
+- Parsing/regex denial-of-service against the host editor
+- Arbitrary code paths exposed by extension commands
+- Decoration content that could be rendered in unintended places
+
+please report it privately:
+
+➔ https://github.com/lacymorrow/vscode-if-end-marker/security/advisories/new
+
+Or email **lacy@lacymorrow.com** with `[vscode-if-end-marker security]` in the subject.
+
+Expect an acknowledgement within 72 hours.
+
+## Supported versions
+
+Only the latest published version on the VS Code Marketplace receives security updates.
+
+## Scope
+
+In scope:
+- The published `shipkit.vscode-if-end-marker` extension
+- Parser, decoration provider, command registrations
+
+Out of scope:
+- Vulnerabilities in VS Code itself — report to [microsoft/vscode](https://github.com/microsoft/vscode)
+- Issues that require an attacker who can already modify your local source files

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build + lint (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["18", "20", "22"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint (tsc --noEmit)
+        run: npm run lint
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Verify build output
+        run: |
+          test -f out/extension.js


### PR DESCRIPTION
Minimal touch — the README, logo, and demo GIF are already polished and intentionally preserved. Adds the missing .github/ community scaffolding (FUNDING, dependabot, ISSUE_TEMPLATE bug/feature/config, PR template, SECURITY) and a CI workflow that runs tsc lint + compile on Node 18/20/22.