### PR TITLE
fix(readme): replace retired shields.io marketplace badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 # VS Code If-End Marker
 
-[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/shipkit.vscode-if-end-marker?style=for-the-badge&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
-[![Downloads](https://img.shields.io/visual-studio-marketplace/d/shipkit.vscode-if-end-marker?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
-[![Rating](https://img.shields.io/visual-studio-marketplace/r/shipkit.vscode-if-end-marker?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
+[![VS Marketplace Version](https://vsmarketplacebadges.dev/version-short/shipkit.vscode-if-end-marker.svg?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
+[![Installs](https://vsmarketplacebadges.dev/installs/shipkit.vscode-if-end-marker.svg)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
+[![Rating](https://vsmarketplacebadges.dev/rating-short/shipkit.vscode-if-end-marker.svg)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker&ssr=false#review-details)
+[![CI](https://img.shields.io/github/actions/workflow/status/lacymorrow/vscode-if-end-marker/ci.yml?style=flat&label=CI)](https://github.com/lacymorrow/vscode-if-end-marker/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat)](https://opensource.org/licenses/MIT)
 
 > Never lose track of which `if` statement you're closing again! 🎯
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![VS Marketplace Version](https://vsmarketplacebadges.dev/version-short/shipkit.vscode-if-end-marker.svg?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
 [![Installs](https://vsmarketplacebadges.dev/installs/shipkit.vscode-if-end-marker.svg)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker)
-[![Rating](https://vsmarketplacebadges.dev/rating-short/shipkit.vscode-if-end-marker.svg)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker&ssr=false#review-details)
+[![Rating](https://vsmarketplacebadges.dev/rating-short/shipkit.vscode-if-end-marker.svg)](https://marketplace.visualstudio.com/items?itemName=shipkit.vscode-if-end-marker#review-details)
 [![CI](https://img.shields.io/github/actions/workflow/status/lacymorrow/vscode-if-end-marker/ci.yml?style=flat&label=CI)](https://github.com/lacymorrow/vscode-if-end-marker/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Why

shields.io [retired](https://github.com/badges/shields/issues/9728) the entire \`visual-studio-marketplace/*\` badge category. All three badges in the README — version, downloads, rating — now render as the literal text **\"retired badge\"** on a grey background.

## Fix

| Badge | Was | Now |
|---|---|---|
| Version | \`shields.io/visual-studio-marketplace/v/…\` (retired) | \`vsmarketplacebadges.dev/version-short/…\` (live) |
| Installs | \`shields.io/visual-studio-marketplace/d/…\` (retired) | \`vsmarketplacebadges.dev/installs/…\` (live) |
| Rating | \`shields.io/visual-studio-marketplace/r/…\` (retired) | \`vsmarketplacebadges.dev/rating-short/…\` (live, links to review tab) |
| CI | — | \`shields.io/github/actions/workflow/status/…\` (added) |
| License | for-the-badge | flat (consistency with marketplace row) |

\`vsmarketplacebadges.dev\` is the modern community replacement for the retired shields.io routes — same SVG-badge interface, returns live data from the Marketplace API.

## Test plan

- [x] Confirmed all three retired URLs return literal "retired badge" SVGs
- [x] Confirmed the three replacement URLs return live data (v0.3.1, 67 installs, 5/5 rating)
- [ ] Badges render correctly on the PR's README preview