### PR TITLE
fix(parser): correctly skip braceless if statements in C/C++

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-if-end-marker",
-  "version": "0.0.5",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-if-end-marker",
-      "version": "0.0.5",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-if-end-marker",
   "displayName": "If End Marker",
   "description": "Never lose track of which if statement you're closing! Shows inline markers with the original condition at closing braces in JS/TS/C/C++ files.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "shipkit",
   "author": {
     "name": "Lacy Morrow",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -141,59 +141,126 @@ export class ASTParser {
         return -1; // not a literal/comment
     }
 
+    private findConditionEnd(lines: string[], startLine: number): { line: number; col: number } | null {
+        const line = lines[startLine];
+        const ifPos = line.indexOf('if');
+        if (ifPos === -1) { return null; }
+        const conditionStart = line.indexOf('(', ifPos);
+        if (conditionStart === -1) { return null; }
+
+        let parenCount = 0;
+
+        for (let i = startLine; i < lines.length && i < startLine + CONFIG_DEFAULTS.MAX_CONDITION_SEARCH_LINES; i++) {
+            const currentLine = lines[i];
+            const startChar = i === startLine ? conditionStart : 0;
+
+            for (let j = startChar; j < currentLine.length; j++) {
+                const ch = currentLine[j];
+
+                if (ch === '"' || ch === '\'' || ch === '`') {
+                    j++;
+                    while (j < currentLine.length) {
+                        if (currentLine[j] === '\\') { j++; }
+                        else if (currentLine[j] === ch) { break; }
+                        j++;
+                    }
+                    continue;
+                }
+                if (ch === '/' && j + 1 < currentLine.length && currentLine[j + 1] === '/') {
+                    break;
+                }
+                if (ch === '/' && j + 1 < currentLine.length && currentLine[j + 1] === '*') {
+                    j += 2;
+                    while (j < currentLine.length) {
+                        if (currentLine[j] === '*' && j + 1 < currentLine.length && currentLine[j + 1] === '/') {
+                            j++;
+                            break;
+                        }
+                        j++;
+                    }
+                    continue;
+                }
+
+                if (ch === '(') { parenCount++; }
+                else if (ch === ')') {
+                    parenCount--;
+                    if (parenCount === 0) {
+                        return { line: i, col: j };
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Finds the end of an if block by matching braces.
      * Skips braces inside strings, template literals, and comments.
+     * Only looks for the opening brace on the condition-end line or the
+     * first non-blank line after it, so braceless if statements are
+     * correctly skipped.
      */
     private findIfBlockEnd(lines: string[], startLine: number): IfStatement | null {
         const startLineText = lines[startLine];
         const condition = this.extractFullCondition(lines, startLine);
         const startColumn = startLineText.indexOf('if');
-        
-        let blockStartLine = startLine;
-        let foundOpenBrace = false;
+
+        const condEnd = this.findConditionEnd(lines, startLine);
+        if (!condEnd) { return null; }
+
+        let blockStartLine = -1;
         let braceSearchStart = 0;
 
-        const ifPos = startColumn >= 0 ? startColumn : 0;
-        const braceOnStartLine = lines[startLine].indexOf('{', ifPos);
-        if (braceOnStartLine !== -1) {
-            foundOpenBrace = true;
-            braceSearchStart = braceOnStartLine;
-        } else {
-            for (let i = startLine + 1; i < lines.length && i < startLine + CONFIG_DEFAULTS.MAX_BRACE_SEARCH_LINES; i++) {
-                if (lines[i].includes('{')) {
-                    blockStartLine = i;
-                    foundOpenBrace = true;
-                    break;
-                }
+        const condEndLineText = lines[condEnd.line];
+        for (let j = condEnd.col + 1; j < condEndLineText.length; j++) {
+            const ch = condEndLineText[j];
+            if (ch === '{') {
+                blockStartLine = condEnd.line;
+                braceSearchStart = j;
+                break;
+            }
+            if (ch !== ' ' && ch !== '\t') {
+                return null;
             }
         }
 
-        if (!foundOpenBrace) {
-            return null;
+        if (blockStartLine === -1) {
+            for (let i = condEnd.line + 1; i < lines.length && i <= condEnd.line + 2; i++) {
+                const trimmed = lines[i].trim();
+                if (trimmed === '') { continue; }
+                if (trimmed[0] === '{') {
+                    blockStartLine = i;
+                    braceSearchStart = lines[i].indexOf('{');
+                    break;
+                }
+                return null;
+            }
         }
+
+        if (blockStartLine === -1) { return null; }
 
         let braceCount = 0;
         const ctx = { line: 0, pos: 0 };
+        let i = blockStartLine;
+        let nextPos = braceSearchStart;
 
-        for (let i = blockStartLine; i < lines.length; i++) {
+        while (i < lines.length) {
             const line = lines[i];
-            let pos = (i === blockStartLine && braceSearchStart > 0) ? braceSearchStart : 0;
-            
+            let pos = nextPos;
+            nextPos = 0;
+
             while (pos < line.length) {
                 const ch = line[pos];
 
-                // Skip string literals, template literals, and comments
                 if (ch === '"' || ch === '\'' || ch === '`' || (ch === '/' && pos + 1 < line.length && (line[pos + 1] === '/' || line[pos + 1] === '*'))) {
                     ctx.line = i;
                     ctx.pos = pos;
                     const end = ASTParser.skipLiteral(lines, i, pos, ctx);
                     if (end !== -1) {
-                        // If the literal spans multiple lines, jump ahead
                         if (ctx.line !== i) {
                             i = ctx.line;
-                            pos = ctx.pos + 1;
-                            // Need to update line reference for the outer while
+                            nextPos = ctx.pos + 1;
                             break;
                         }
                         pos = end + 1;
@@ -205,7 +272,7 @@ export class ASTParser {
                     braceCount++;
                 } else if (ch === '}') {
                     braceCount--;
-                    
+
                     if (braceCount === 0) {
                         return {
                             condition,
@@ -218,8 +285,11 @@ export class ASTParser {
                 }
                 pos++;
             }
+
+            if (nextPos > 0) { continue; }
+            i++;
         }
-        
+
         return null;
     }
     

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -289,6 +289,96 @@ if (status == 0) {
         assert.strictEqual(results[2].condition, 'status < 0');
     });
 
+    // --- Braceless if statements ---
+
+    test('Should skip braceless if with statement on next line (C style)', () => {
+        const code = `
+if (retval)
+    return retval;
+
+if (dev->going_away) {
+    retval = -ENODEV;
+    goto out;
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'dev->going_away');
+    });
+
+    test('Should skip braceless if followed by braced if (input.c pattern)', () => {
+        const code = `
+if (!dev->users++ && dev->open)
+    retval = dev->open(dev);
+
+if (retval) {
+    dev->users--;
+    if (!--handle->open) {
+        synchronize_rcu();
+    }
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 2);
+        assert.strictEqual(results[0].condition, 'retval');
+        assert.strictEqual(results[0].startLine, 4);
+        assert.strictEqual(results[0].endLine, 8);
+        assert.strictEqual(results[1].condition, '!--handle->open');
+        assert.strictEqual(results[1].startLine, 6);
+        assert.strictEqual(results[1].endLine, 8);
+    });
+
+    test('Should skip braceless if with inline statement (same line)', () => {
+        const code = `
+if (error) return -1;
+if (valid) {
+    process();
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'valid');
+    });
+
+    test('Should handle full input_open_device function from issue #6', () => {
+        const code = `int input_open_device(struct input_handle *handle)
+{
+\tstruct input_dev *dev = handle->dev;
+\tint retval;
+
+\tretval = mutex_lock_interruptible(&dev->mutex);
+\tif (retval)
+\t\treturn retval;
+
+\tif (dev->going_away) {
+\t\tretval = -ENODEV;
+\t\tgoto out;
+\t}
+
+\thandle->open++;
+
+\tif (!dev->users++ && dev->open)
+\t\tretval = dev->open(dev);
+
+\tif (retval) {
+\t\tdev->users--;
+\t\tif (!--handle->open) {
+\t\t\tsynchronize_rcu();
+\t\t}
+\t}
+
+ out:
+\tmutex_unlock(&dev->mutex);
+\treturn retval;
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 3);
+        assert.strictEqual(results[0].condition, 'dev->going_away');
+        assert.strictEqual(results[1].condition, 'retval');
+        assert.strictEqual(results[2].condition, '!--handle->open');
+    });
+
     // --- Edge cases ---
 
     test('Should handle empty code', () => {


### PR DESCRIPTION
## Summary

- Fixes the parser incorrectly matching braceless `if` statements (e.g., `if (retval) return retval;`) to braces from unrelated code below, producing wrong end markers
- The parser now finds where the `if (...)` condition closes, then only looks for `{` on the same line or the first non-blank line after — correctly skipping braceless if statements
- Fixes a secondary bug where multi-line literal/comment skips caused the brace-counting loop to skip content on the target line

## Test plan

- Added 4 new test cases covering:
  - [x] Braceless if with statement on next line (C kernel style)
  - [x] Braceless if followed by braced if (exact pattern from issue #6)
  - [x] Braceless if with inline statement on same line
  - [x] Full `input_open_device` function from the reporter's file
- [x] All existing tests continue to pass
- [x] Verified against the full 1974-line `input.c` file from the issue — 43 if statements correctly identified, all markers point to actual closing braces

Closes #6