### PR TITLE
fix(parser): handle comments between condition and opening brace

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -220,6 +220,25 @@ export class ASTParser {
                 braceSearchStart = j;
                 break;
             }
+            if (ch === '/' && j + 1 < condEndLineText.length) {
+                if (condEndLineText[j + 1] === '/') {
+                    break;
+                }
+                if (condEndLineText[j + 1] === '*') {
+                    let k = j + 2;
+                    let closed = false;
+                    while (k < condEndLineText.length - 1) {
+                        if (condEndLineText[k] === '*' && condEndLineText[k + 1] === '/') {
+                            j = k + 1;
+                            closed = true;
+                            break;
+                        }
+                        k++;
+                    }
+                    if (!closed) { break; }
+                    continue;
+                }
+            }
             if (ch !== ' ' && ch !== '\t') {
                 return null;
             }

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -322,7 +322,7 @@ if (retval) {
         assert.strictEqual(results.length, 2);
         assert.strictEqual(results[0].condition, 'retval');
         assert.strictEqual(results[0].startLine, 4);
-        assert.strictEqual(results[0].endLine, 8);
+        assert.strictEqual(results[0].endLine, 9);
         assert.strictEqual(results[1].condition, '!--handle->open');
         assert.strictEqual(results[1].startLine, 6);
         assert.strictEqual(results[1].endLine, 8);
@@ -377,6 +377,46 @@ if (valid) {
         assert.strictEqual(results[0].condition, 'dev->going_away');
         assert.strictEqual(results[1].condition, 'retval');
         assert.strictEqual(results[2].condition, '!--handle->open');
+    });
+
+    // --- Comments between condition and brace ---
+
+    test('Should handle single-line comment between condition and next-line brace', () => {
+        const code = `
+if (g_ucSerBuf[STATUS] == 0x00) //STATUS=2
+{
+    return CommandOk;
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'g_ucSerBuf[STATUS] == 0x00');
+        assert.strictEqual(results[0].startLine, 1);
+        assert.strictEqual(results[0].endLine, 4);
+    });
+
+    test('Should handle block comment between condition and brace on same line', () => {
+        const code = `
+if (condition) /* checked */ {
+    run();
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'condition');
+    });
+
+    test('Should still skip braceless if with comment', () => {
+        const code = `
+if (error) //check
+    return -1;
+if (valid) {
+    process();
+}`;
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'valid');
     });
 
     // --- Edge cases ---


### PR DESCRIPTION
## Summary

- The braceless-if detection from v0.3.2 treated any non-whitespace character between `)` and `{` as a braceless if, returning null
- C/C++ code commonly places `//` or `/* */` comments between the closing paren and the opening brace (e.g., `if (status == OK) //check` followed by `{` on the next line)
- This broke all markers for affected C/C++ files — reported in #22
- Now skips single-line and inline block comments so the brace search falls through to the next-line check
- Also fixes a pre-existing test with incorrect `endLine` expectation

## Test plan

- [x] New test: single-line comment between condition and next-line brace
- [x] New test: block comment between condition and brace on same line
- [x] New test: braceless if with comment still correctly skipped
- [x] Pre-existing test fix: corrected outer if block endLine (8 → 9)
- [x] All 43 tests pass

Closes #22