### PR TITLE
fix(parser): normalize CRLF line endings before parsing

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -33,7 +33,7 @@ export class ASTParser {
      */
     parse(code: string, languageId: string): IfStatement[] {
         const ifStatements: IfStatement[] = [];
-        const lines = code.split('\n');
+        const lines = code.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
         
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -419,6 +419,54 @@ if (valid) {
         assert.strictEqual(results[0].condition, 'valid');
     });
 
+    // --- CRLF line endings ---
+
+    test('Should handle CRLF line endings with brace on next line', () => {
+        const code = "if (condition)\r\n{\r\n    console.log('test');\r\n}";
+        const results = parser.parse(code, 'javascript');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'condition');
+    });
+
+    test('Should handle CRLF in C code with preprocessor directives', () => {
+        const code = [
+            'void func(void)',
+            '{',
+            '  #if(UART_INT == 1)',
+            '  receive_data();',
+            '  #endif',
+            '  if (status == 0x00 && seq == (buf[CMD] & 0xf0))',
+            '  {',
+            '    memcpy(dst, &buf[DATA], len);',
+            '    return OK;',
+            '  }',
+            '  else',
+            '    return ERR;',
+            '}',
+        ].join('\r\n');
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'status == 0x00 && seq == (buf[CMD] & 0xf0)');
+    });
+
+    test('Should handle CRLF with comment after condition', () => {
+        const code = "if (status == 0x00) //check\r\n{\r\n    return OK;\r\n}";
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'status == 0x00');
+    });
+
+    test('Should handle CRLF with brace on same line', () => {
+        const code = "if (x > 0) {\r\n    process(x);\r\n}";
+        const results = parser.parse(code, 'c');
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].condition, 'x > 0');
+    });
+
     // --- Edge cases ---
 
     test('Should handle empty code', () => {


### PR DESCRIPTION
## Summary
- Files with Windows-style CRLF (`\r\n`) line endings broke the parser — the `\r` at end of each line was treated as non-whitespace in the brace-search loop, causing `findIfBlockEnd` to return `null` for nearly all if statements
- Root cause: `code.split('\n')` leaves `\r` on each line for CRLF files; the brace-search whitespace check on parser.ts:242 only allowed ` ` and `\t`
- Fix: normalize `\r\n` and bare `\r` to `\n` at the start of `parse()` — one line, zero impact on LF-only files
- Tested against the reporter's actual 1926-line C file: **2 → 37 if statements detected**

## Test plan
- [x] 4 new CRLF-specific regression tests (next-line braces, preprocessor directives, comment after condition, same-line brace)
- [x] All 47 tests passing
- [x] Verified against user's attached `ZLG600Drive.c` file from issue #24

Closes #24